### PR TITLE
revert a change made to try-catch

### DIFF
--- a/src/GetOrderLookup.php
+++ b/src/GetOrderLookup.php
@@ -55,12 +55,14 @@ final readonly class GetOrderLookup implements TransformerInterface
                 $output = ($this->mapper)($lookup, $line);
 
                 $line = yield new AcceptanceResultBucket($output);
+            } catch (NoContentException) {
+                $line = yield new AcceptanceResultBucket($line);
             } catch (InternalServerErrorException|ApiRateExceededException $exception) {
                 $this->logger->critical($exception->getMessage(), ['exception' => $exception, 'item' => $line]);
                 $line = yield new RejectionResultBucket($line);
 
                 return;
-            } catch (NoContentException|BadRequestException|ForbiddenException|RequestEntityTooLargeException|NotFoundException $exception) {
+            } catch (BadRequestException|ForbiddenException|RequestEntityTooLargeException|NotFoundException $exception) {
                 $this->logger->error($exception->getMessage(), ['exception' => $exception, 'item' => $line]);
                 $line = yield new RejectionResultBucket($line);
                 continue;


### PR DESCRIPTION
 Order Lookup should be able to not find any result without stopping the pipeline.